### PR TITLE
fix email for additional email and register flow

### DIFF
--- a/a4-speakup/templates/account/email/email_confirmation.en.email
+++ b/a4-speakup/templates/account/email/email_confirmation.en.email
@@ -5,12 +5,12 @@
 {% block headline %}Your email address on {{ site.name }}{% endblock %}
 
 {% block content %}
-Your email address has been added to the username “{{ receiver.username }}” on <i>{{ site.name }}</i>. Please click the {% if part_type == 'txt' %}link{% else %}button{% endif %} below to confirm your email address.
+Your email address has been added to the username “{{ user.username }}” on <i>{{ site.name }}</i>. Please click the {% if part_type == 'txt' %}link{% else %}button{% endif %} below to confirm your email address.
 {% endblock %}
 
 {% block cta_url %}{{ activate_url }}{% endblock %}
 {% block cta_label %}Confirm your email address{% endblock %}
 
 {% block reason %}
-This email was sent to {{ receiver.email }}. If you think this email was sent to you by mistake, you can ignore it. We will not send you any further emails. If you have any further questions, please contact us via {{ contact_email }}
+This email was sent to {{ receiver }}. If you think this email was sent to you by mistake, you can ignore it. We will not send you any further emails. If you have any further questions, please contact us via {{ contact_email }}
 {% endblock %}

--- a/a4-speakup/templates/account/email/email_confirmation_signup.en.email
+++ b/a4-speakup/templates/account/email/email_confirmation_signup.en.email
@@ -5,12 +5,12 @@
 {% block headline %}Your registration on {{ site.name }}{% endblock %}
 
 {% block content %}
-Your email address has been used to register on <i>{{ site.name }}</i> with the username “{{ receiver.username }}”. Please click on the button below to confirm your email address and activate your account.
+Your email address has been used to register on <i>{{ site.name }}</i> with the username “{{ user.username }}”. Please click on the button below to confirm your email address and activate your account.
 {% endblock %}
 
 {% block cta_url %}{{ activate_url }}{% endblock %}
 {% block cta_label %}Confirm your email address{% endblock %}
 
 {% block reason %}
-This email was sent to {{ receiver.email }}. If you think this email was sent to you by mistake, you can ignore it. We will not send you any further emails. If you have any further questions, please contact us via {{ contact_email }}
+This email was sent to {{ user }}. If you think this email was sent to you by mistake, you can ignore it. We will not send you any further emails. If you have any further questions, please contact us via {{ contact_email }}
 {% endblock %}

--- a/a4-speakup/templates/account/email/password_reset_key.en.email
+++ b/a4-speakup/templates/account/email/password_reset_key.en.email
@@ -2,7 +2,7 @@
 
 {% block subject %}Reset password request for {{ site.name }}{% endblock %}
 
-{% block headline %}Password reset for your account {{ receiver.username }}{% endblock %}
+{% block headline %}Password reset for your account {{ user.username }}{% endblock %}
 
 {% block content %}
 You have requested a password reset for your account on <i>{{ site.name }}</i>. Please click the  {% if part_type == 'txt' %}link{% else %}button{% endif %} below to set your new password.
@@ -12,5 +12,5 @@ You have requested a password reset for your account on <i>{{ site.name }}</i>. 
 {% block cta_label %}Reset password{% endblock %}
 
 {% block reason %}
-You receive this email because you have an account on {{ site.name }} with email address {{ receiver.email }}. If you haven't requested a password reset, someone else might have done it on your behalf. In that case you can safely ignore this email, we won't change your password of modify your account.
+You receive this email because you have an account on {{ site.name }} with email address {{ user.email }}. If you haven't requested a password reset, someone else might have done it on your behalf. In that case you can safely ignore this email, we won't change your password of modify your account.
 {% endblock %}

--- a/apps/users/adapters.py
+++ b/apps/users/adapters.py
@@ -39,9 +39,8 @@ class AccountAdapter(DefaultAccountAdapter):
             return url
 
     def send_mail(self, template_prefix, email, context):
-        user = context['user']
         return UserAccountEmail.send(
-            user,
+            email,
             template_name=template_prefix,
             **context
         )


### PR DESCRIPTION
fixes #117 (even though, a secondary email cannot be added, because no settings. Still, it works for normal register and password reset and would work for additional email as soon as we add that.)