### PR TITLE
use email instead of string in register confirm

### DIFF
--- a/a4-speakup/templates/account/email/email_confirmation_signup.en.email
+++ b/a4-speakup/templates/account/email/email_confirmation_signup.en.email
@@ -12,5 +12,5 @@ Your email address has been used to register on <i>{{ site.name }}</i> with the 
 {% block cta_label %}Confirm your email address{% endblock %}
 
 {% block reason %}
-This email was sent to {{ user }}. If you think this email was sent to you by mistake, you can ignore it. We will not send you any further emails. If you have any further questions, please contact us via {{ contact_email }}
+This email was sent to {{ user.email }}. If you think this email was sent to you by mistake, you can ignore it. We will not send you any further emails. If you have any further questions, please contact us via {{ contact_email }}
 {% endblock %}


### PR DESCRIPTION
This current email also works because user has the email as string method, but in this version it's more robust!