### PR TITLE
contrib/management: Add a missing None check

### DIFF
--- a/apps/contrib/management/commands/makemessages.py
+++ b/apps/contrib/management/commands/makemessages.py
@@ -6,7 +6,7 @@ from django.core.management.commands import makemessages
 
 def get_module_dir(name):
     module = __import__(name)
-    if hasattr(module, '__file__'):
+    if hasattr(module, '__file__') and module.__file__:
         return path.dirname(module.__file__)
     else:
         return module.__path__._path[0]


### PR DESCRIPTION
In the case of a4-speakup, hasattr(module, '__file__') returns True
but module.__file__ is None. Probably this behaviour has changed
in a recent Python version.

Fixes https://github.com/liqd/a4-speakup/issues/293