### PR TITLE
 a4-speakup: Add missing init file 

### DIFF
--- a/apps/contrib/management/commands/makemessages.py
+++ b/apps/contrib/management/commands/makemessages.py
@@ -6,10 +6,7 @@ from django.core.management.commands import makemessages
 
 def get_module_dir(name):
     module = __import__(name)
-    if hasattr(module, '__file__'):
-        return path.dirname(module.__file__)
-    else:
-        return module.__path__._path[0]
+    return path.dirname(module.__file__)
 
 
 class Command(makemessages.Command):

--- a/apps/contrib/management/commands/makemessages.py
+++ b/apps/contrib/management/commands/makemessages.py
@@ -6,7 +6,7 @@ from django.core.management.commands import makemessages
 
 def get_module_dir(name):
     module = __import__(name)
-    if hasattr(module, '__file__') and module.__file__:
+    if hasattr(module, '__file__'):
         return path.dirname(module.__file__)
     else:
         return module.__path__._path[0]


### PR DESCRIPTION
This is needed as we import the folder in 'makemessages'
Also remove previously used workaround, introduced in bea62a0,
which broke on recent python version (most likely).