### PR TITLE
Revert "settings: remove raven_compat from installed apps"

### DIFF
--- a/a4-speakup/settings/base.py
+++ b/a4-speakup/settings/base.py
@@ -40,6 +40,7 @@ INSTALLED_APPS = [
     'ckeditor',
     'ckeditor_uploader',
     'background_task',
+    'raven.contrib.django.raven_compat',
 
     'django.contrib.sites',
     'django.contrib.admin',


### PR DESCRIPTION
Reverts liqd/a4-speakup#446

No, doesn't fix it and should be there! But why is A+ working without that?